### PR TITLE
feat(api): add trials, vote, and leaderboard endpoints

### DIFF
--- a/apps/web/app/api/leaderboard/route.ts
+++ b/apps/web/app/api/leaderboard/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/src/lib/prisma";
+import type { LeaderboardResponse } from "@/src/lib/validations/leaderboard";
+
+export async function GET() {
+  const models = await prisma.model.findMany({
+    where: { isActive: true },
+    include: {
+      arms: {
+        include: {
+          trials: {
+            where: { outcome: { not: null } },
+          },
+        },
+      },
+    },
+  });
+
+  const leaderboard: LeaderboardResponse = models
+    .map((model) => {
+      const trials = model.arms.flatMap((arm) => arm.trials);
+      const totalTrials = trials.length;
+
+      if (totalTrials === 0) {
+        return {
+          modelId: model.id,
+          modelName: model.name,
+          successRate: 0,
+          avgNaturalness: 0,
+          avgAudioQuality: 0,
+          totalScore: 0,
+          totalTrials: 0,
+        };
+      }
+
+      const successCount = trials.filter(
+        (t) => t.outcome === "SUCCESS"
+      ).length;
+      const successRate = successCount / totalTrials;
+
+      const avgNaturalness =
+        trials.reduce((sum, t) => sum + (t.naturalness ?? 0), 0) / totalTrials;
+      const avgAudioQuality =
+        trials.reduce((sum, t) => sum + (t.audioQuality ?? 0), 0) / totalTrials;
+
+      // averageScore: mean of naturalness and audioQuality normalized from 1-5 to 0-1
+      const averageScore = ((avgNaturalness + avgAudioQuality) / 2 - 1) / 4;
+      const totalScore = 0.5 * successRate + 0.5 * averageScore;
+
+      return {
+        modelId: model.id,
+        modelName: model.name,
+        successRate: Math.round(successRate * 1000) / 1000,
+        avgNaturalness: Math.round(avgNaturalness * 100) / 100,
+        avgAudioQuality: Math.round(avgAudioQuality * 100) / 100,
+        totalScore: Math.round(totalScore * 1000) / 1000,
+        totalTrials,
+      };
+    })
+    .sort((a, b) => b.totalScore - a.totalScore);
+
+  return NextResponse.json(leaderboard);
+}

--- a/apps/web/app/api/matchups/vote/route.ts
+++ b/apps/web/app/api/matchups/vote/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/src/lib/prisma";
+import {
+  matchupVoteRequestSchema,
+  type MatchupVoteResponse,
+} from "@/src/lib/validations/matchup";
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const parsed = matchupVoteRequestSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0].message },
+      { status: 400 }
+    );
+  }
+
+  const { matchupId, choice, rationale } = parsed.data;
+
+  const matchup = await prisma.matchup.findUnique({
+    where: { id: matchupId },
+    include: { vote: true },
+  });
+
+  if (!matchup) {
+    return NextResponse.json(
+      { error: "Matchup not found" },
+      { status: 404 }
+    );
+  }
+
+  if (matchup.vote) {
+    return NextResponse.json(
+      { error: "Matchup already voted" },
+      { status: 409 }
+    );
+  }
+
+  const result = await prisma.$transaction(async (tx) => {
+    const vote = await tx.matchupVote.create({
+      data: {
+        matchupId,
+        choice,
+        rationale,
+      },
+    });
+
+    await tx.matchup.update({
+      where: { id: matchupId },
+      data: { status: "COMPLETED" },
+    });
+
+    return vote;
+  });
+
+  const responseBody: MatchupVoteResponse = {
+    voteId: result.id,
+    choice: result.choice,
+  };
+
+  return NextResponse.json(responseBody, { status: 201 });
+}

--- a/apps/web/app/api/trials/complete/route.ts
+++ b/apps/web/app/api/trials/complete/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/src/lib/prisma";
+import {
+  completeTrialRequestSchema,
+  type CompleteTrialResponse,
+} from "@/src/lib/validations/trial";
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const parsed = completeTrialRequestSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0].message },
+      { status: 400 }
+    );
+  }
+
+  const { trialId, outcome, naturalness, audioQuality } = parsed.data;
+
+  const trial = await prisma.trial.findUnique({
+    where: { id: trialId },
+  });
+
+  if (!trial) {
+    return NextResponse.json(
+      { error: "Trial not found" },
+      { status: 404 }
+    );
+  }
+
+  if (trial.outcome !== null) {
+    return NextResponse.json(
+      { error: "Trial already completed" },
+      { status: 409 }
+    );
+  }
+
+  const updated = await prisma.trial.update({
+    where: { id: trialId },
+    data: {
+      outcome,
+      naturalness,
+      audioQuality,
+      endedAt: new Date(),
+    },
+  });
+
+  const responseBody: CompleteTrialResponse = {
+    trialId: updated.id,
+    outcome: updated.outcome!,
+    naturalness: updated.naturalness!,
+    audioQuality: updated.audioQuality!,
+  };
+
+  return NextResponse.json(responseBody);
+}

--- a/apps/web/app/api/trials/start/route.ts
+++ b/apps/web/app/api/trials/start/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/src/lib/prisma";
+import {
+  startTrialRequestSchema,
+  type StartTrialResponse,
+} from "@/src/lib/validations/trial";
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const parsed = startTrialRequestSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0].message },
+      { status: 400 }
+    );
+  }
+
+  const { matchupId, armId, trialIndex } = parsed.data;
+
+  const matchup = await prisma.matchup.findUnique({
+    where: { id: matchupId },
+  });
+
+  if (!matchup) {
+    return NextResponse.json(
+      { error: "Matchup not found" },
+      { status: 404 }
+    );
+  }
+
+  if (matchup.status !== "IN_PROGRESS") {
+    return NextResponse.json(
+      { error: "Matchup is not in progress" },
+      { status: 409 }
+    );
+  }
+
+  const arm = await prisma.matchupArm.findUnique({
+    where: { id: armId },
+    include: { model: true },
+  });
+
+  if (!arm || arm.matchupId !== matchupId) {
+    return NextResponse.json(
+      { error: "Arm not found or does not belong to this matchup" },
+      { status: 404 }
+    );
+  }
+
+  if (trialIndex > arm.trialsRequired) {
+    return NextResponse.json(
+      { error: "Trial index exceeds trials required" },
+      { status: 400 }
+    );
+  }
+
+  const trial = await prisma.trial.create({
+    data: {
+      trialIndex,
+      matchupId,
+      armId,
+    },
+  });
+
+  const responseBody: StartTrialResponse = {
+    trialId: trial.id,
+    endpointUrl: arm.model.endpointUrl,
+  };
+
+  return NextResponse.json(responseBody, { status: 201 });
+}

--- a/apps/web/src/lib/validations/leaderboard.ts
+++ b/apps/web/src/lib/validations/leaderboard.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const leaderboardEntrySchema = z.object({
+  modelId: z.string(),
+  modelName: z.string(),
+  successRate: z.number(),
+  avgNaturalness: z.number(),
+  avgAudioQuality: z.number(),
+  totalScore: z.number(),
+  totalTrials: z.number(),
+});
+
+export type LeaderboardEntry = z.infer<typeof leaderboardEntrySchema>;
+
+export const leaderboardResponseSchema = z.array(leaderboardEntrySchema);
+
+export type LeaderboardResponse = z.infer<typeof leaderboardResponseSchema>;

--- a/apps/web/src/lib/validations/matchup.ts
+++ b/apps/web/src/lib/validations/matchup.ts
@@ -14,3 +14,19 @@ export const createMatchupResponseSchema = z.object({
 });
 
 export type CreateMatchupResponse = z.infer<typeof createMatchupResponseSchema>;
+
+// POST /api/matchups/vote
+export const matchupVoteRequestSchema = z.object({
+  matchupId: z.string(),
+  choice: z.enum(["A", "B", "DRAW"]),
+  rationale: z.string().optional(),
+});
+
+export type MatchupVoteRequest = z.infer<typeof matchupVoteRequestSchema>;
+
+export const matchupVoteResponseSchema = z.object({
+  voteId: z.string(),
+  choice: z.enum(["A", "B", "DRAW"]),
+});
+
+export type MatchupVoteResponse = z.infer<typeof matchupVoteResponseSchema>;

--- a/apps/web/src/lib/validations/trial.ts
+++ b/apps/web/src/lib/validations/trial.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+// POST /api/trials/start
+export const startTrialRequestSchema = z.object({
+  matchupId: z.string(),
+  armId: z.string(),
+  trialIndex: z.number().int().min(1),
+});
+
+export type StartTrialRequest = z.infer<typeof startTrialRequestSchema>;
+
+export const startTrialResponseSchema = z.object({
+  trialId: z.string(),
+  endpointUrl: z.string(),
+});
+
+export type StartTrialResponse = z.infer<typeof startTrialResponseSchema>;
+
+// POST /api/trials/complete
+export const completeTrialRequestSchema = z.object({
+  trialId: z.string(),
+  outcome: z.enum(["SUCCESS", "FAILURE"]),
+  naturalness: z.number().int().min(1).max(5),
+  audioQuality: z.number().int().min(1).max(5),
+});
+
+export type CompleteTrialRequest = z.infer<typeof completeTrialRequestSchema>;
+
+export const completeTrialResponseSchema = z.object({
+  trialId: z.string(),
+  outcome: z.enum(["SUCCESS", "FAILURE"]),
+  naturalness: z.number(),
+  audioQuality: z.number(),
+});
+
+export type CompleteTrialResponse = z.infer<typeof completeTrialResponseSchema>;


### PR DESCRIPTION
Add the remaining 4 API endpoints to complete the evaluation flow:
- POST /api/trials/start — create trial and return endpoint URL
- POST /api/trials/complete — record trial outcome and scores
- POST /api/matchups/vote — record A/B comparison vote
- GET /api/leaderboard — return model rankings with aggregated stats